### PR TITLE
feat: switch api over to trpc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,17 @@
       "name": "hillpointe_demo",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.81.2",
+        "@trpc/client": "^11.4.2",
+        "@trpc/next": "^11.4.2",
+        "@trpc/react-query": "^11.4.2",
+        "@trpc/server": "^11.4.2",
         "framer-motion": "^12.18.1",
         "lucide-react": "^0.515.0",
         "next": "15.3.3",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^3.25.67"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -1194,6 +1200,101 @@
         "@tailwindcss/oxide": "4.1.10",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.10"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.81.2.tgz",
+      "integrity": "sha512-QLYkPdrudoMATDFa3MiLEwRhNnAlzHWDf0LKaXUqJd0/+QxN8uTPi7bahRlxoAyH0UbLMBdeDbYzWALj7THOtw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.81.2.tgz",
+      "integrity": "sha512-pe8kFlTrL2zFLlcAj2kZk9UaYYHDk9/1hg9EBaoO3cxDhOZf1FRGJeziSXKrVZyxIfs7b3aoOj/bw7Lie0mDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.81.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@trpc/client": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.4.2.tgz",
+      "integrity": "sha512-Eep1rorAsATs9bxgaXf+BV34CRs4lAKQmwumUL4CNdNDkJItyfuWUr3xWx0np1w3EzUDVA0YDMK93iKDBBA0KQ==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@trpc/server": "11.4.2",
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/next": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@trpc/next/-/next-11.4.2.tgz",
+      "integrity": "sha512-TprETSb4NECbBp6OClcedH9mugTyGJYEWRV7nQRVIOumZUTDlsYZSb08baGIBEMWNvHqFwOLAvvpwiDNPK8xaA==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.59.15",
+        "@trpc/client": "11.4.2",
+        "@trpc/react-query": "11.4.2",
+        "@trpc/server": "11.4.2",
+        "next": "*",
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0",
+        "typescript": ">=5.7.2"
+      },
+      "peerDependenciesMeta": {
+        "@tanstack/react-query": {
+          "optional": true
+        },
+        "@trpc/react-query": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trpc/react-query": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@trpc/react-query/-/react-query-11.4.2.tgz",
+      "integrity": "sha512-tm2y9asG3PmdyZqgE92hQEauxls/2ZlEMpA6y/hLizdhjLiKCEtYCQ38pU+n4vUYczffZ90aTaSFm7zf+tnz/g==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.80.3",
+        "@trpc/client": "11.4.2",
+        "@trpc/server": "11.4.2",
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/server": {
+      "version": "11.4.2",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.4.2.tgz",
+      "integrity": "sha512-THyq/V5bSFDHeWEAk6LqHF0IVTGk6voGwWsFEipzRRKOWWMIZINCsKZ4cISG6kWO2X9jBfMWv/S2o9hnC0zQ0w==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.7.2"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -5616,7 +5717,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5820,6 +5920,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,17 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.81.2",
+    "@trpc/client": "^11.4.2",
+    "@trpc/next": "^11.4.2",
+    "@trpc/react-query": "^11.4.2",
+    "@trpc/server": "^11.4.2",
     "framer-motion": "^12.18.1",
     "lucide-react": "^0.515.0",
     "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^3.25.67"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,14 @@
+import { fetchRequestHandler } from '@trpc/server/adapters/fetch';
+import { type NextRequest } from 'next/server';
+
+import { appRouter } from '@/server';
+
+const handler = (req: NextRequest) =>
+  fetchRequestHandler({
+    endpoint: '/api/trpc',
+    req,
+    router: appRouter,
+    createContext: () => ({}),
+  });
+
+export { handler as GET, handler as POST };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
+import Provider from "@/lib/trpc/Provider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,8 +29,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Header />
-        {children}
+        <Provider>
+          <Header />
+          {children}
+        </Provider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,8 @@
 import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
-import useParallax from '@/hooks/useParallax'; 
+import useParallax from '@/hooks/useParallax';
+import { trpc } from '@/lib/trpc/client';
 
 const progressBarVariants = {
   initial: { width: '0%' },
@@ -13,12 +14,13 @@ const progressBarVariants = {
 };
 
 export default function Home() {
-  const [loading, setLoading] = useState(true);
+  const { data: products, error, isLoading } = trpc.getLoanProducts.useQuery();
+  const [showLoading, setShowLoading] = useState(true);
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      setLoading(false);
-    }, 3000); // Show loading for 3 seconds
+      setShowLoading(false);
+    }, 3000);
 
     return () => clearTimeout(timer);
   }, []);
@@ -47,7 +49,7 @@ export default function Home() {
     },
   };
 
-  if (loading) {
+  if (showLoading || isLoading) {
     return (
       <motion.div
         className="fixed inset-0 z-[100] flex flex-col items-center justify-center bg-white"
@@ -69,6 +71,14 @@ export default function Home() {
           />
         </div>
       </motion.div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center h-screen text-red-500">
+        {error.message}
+      </div>
     );
   }
 
@@ -115,6 +125,23 @@ export default function Home() {
             />
             <div className='hero-image-overlay responsive-iphone-screen absolute bg-slate-400 top-[320px] z-40 opacity-30' />
           </div>
+        </div>
+      </div>
+      <div className="section section-two">
+        <h2 className="text-3xl font-bold text-center mb-8">Our Loan Products</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+          {products?.map((product) => (
+            <div key={product.id} className="border p-4 rounded-lg">
+              <h3 className="text-xl font-bold">{product.title}</h3>
+              <p>{product.propertyType}</p>
+              <p>
+                ${product.loanAmount.min} - ${product.loanAmount.max}
+              </p>
+              <p>Max LTV: {product.maxLtv * 100}%</p>
+              <p>{product.termLength}</p>
+              <p>{product.additionalInfo}</p>
+            </div>
+          ))}
         </div>
       </div>
     </motion.div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,11 +4,31 @@ import Link from 'next/link';
 import { ArrowRight, Menu, X } from 'lucide-react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
+import { trpc } from '@/lib/trpc/client';
 
 const Header = () => {
   const [isVisible, setIsVisible] = useState(true);
   const [lastScrollY, setLastScrollY] = useState(0);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  const { mutate: submitApplication } = trpc.submitApplication.useMutation({
+    onSuccess: (data) => {
+      console.log('Application submitted successfully:', data);
+      alert('Application submitted successfully!');
+    },
+    onError: (error) => {
+      console.error('Failed to submit application:', error);
+      alert('Failed to submit application. Please try again.');
+    },
+  });
+
+  const handleApplyNow = () => {
+    submitApplication({
+      applicantName: 'John Doe',
+      email: 'john.doe@example.com',
+      loanType: 'Single Family',
+    });
+  };
 
   const controlNavbar = () => {
     if (typeof window !== 'undefined') {
@@ -57,10 +77,10 @@ const Header = () => {
               <span>Contact Us</span>
               <ArrowRight size={16} />
             </Link>
-            <Link href="#" className="bg-white text-gray-800 px-4 py-2 rounded-full flex items-center space-x-2 hover:bg-gray-200 text-sm">
+            <button onClick={handleApplyNow} className="bg-white text-gray-800 px-4 py-2 rounded-full flex items-center space-x-2 hover:bg-gray-200 text-sm">
               <span>Apply Now</span>
               <ArrowRight size={16} />
-            </Link>
+            </button>
           </div>
 
           {/* Mobile Menu Button */}

--- a/src/hooks/useParallax.ts
+++ b/src/hooks/useParallax.ts
@@ -4,7 +4,6 @@ const useParallax = (speedFactor: number): string => {
   const [transform, setTransform] = useState('translateY(0px)');
 
   useEffect(() => {
-    // Ensure this code runs only in the client-side environment
     if (typeof window === 'undefined') {
       return;
     }
@@ -15,7 +14,7 @@ const useParallax = (speedFactor: number): string => {
     };
 
     window.addEventListener('scroll', handleScroll);
-    handleScroll(); // Initial call to set position based on current scroll
+    handleScroll(); 
 
     return () => {
       window.removeEventListener('scroll', handleScroll);

--- a/src/lib/mock-data.ts
+++ b/src/lib/mock-data.ts
@@ -1,0 +1,52 @@
+import { LoanProduct } from './schemas';
+
+export const loanProducts: LoanProduct[] = [
+  {
+    id: 1,
+    title: 'Single Family',
+    propertyType: '1-4 Unit / Townhomes / Condos',
+    loanAmount: {
+      min: 300000,
+      max: 3500000,
+    },
+    maxLtv: 0.8,
+    termLength: '30 Year Fixed',
+    additionalInfo: 'Interest Only Option',
+  },
+  {
+    id: 2,
+    title: 'Short Term Rentals',
+    propertyType: '1-4 Unit / Townhomes / Condos',
+    loanAmount: {
+      min: 300000,
+      max: 3500000,
+    },
+    maxLtv: 0.75,
+    termLength: '30 Year Fixed',
+    additionalInfo: 'Interest Only Option',
+  },
+  {
+    id: 3,
+    title: 'Multi Family',
+    propertyType: '5+ Units / Mixed Use',
+    loanAmount: {
+      min: 300000,
+      max: 10000000,
+    },
+    maxLtv: 0.75,
+    termLength: '30 Year Fixed',
+    additionalInfo: 'Interest Only Option',
+  },
+  {
+    id: 4,
+    title: 'Cross Portfolio',
+    propertyType: '1-4 Units / Townhomes / Condos\n5-20 Unit Properties Allowed',
+    loanAmount: {
+      min: 1000000,
+      max: 15000000,
+    },
+    maxLtv: 0.75,
+    termLength: '30 Year Fixed',
+    additionalInfo: 'Interest Only Option',
+  },
+];

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const loanProductSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  propertyType: z.string(),
+  loanAmount: z.object({
+    min: z.number(),
+    max: z.number(),
+  }),
+  maxLtv: z.number(),
+  termLength: z.string(),
+  additionalInfo: z.string(),
+});
+
+export const loanApplicationSchema = z.object({
+  applicantName: z.string(),
+  email: z.string().email(),
+  loanType: z.string(),
+});
+
+export type LoanProduct = z.infer<typeof loanProductSchema>;
+export type LoanApplication = z.infer<typeof loanApplicationSchema>;

--- a/src/lib/trpc/Provider.tsx
+++ b/src/lib/trpc/Provider.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { httpBatchLink } from '@trpc/client';
+import React, { useState } from 'react';
+
+import { trpc } from './client';
+
+export default function Provider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient({}));
+  const [trpcClient] = useState(() =>
+    trpc.createClient({
+      links: [
+        httpBatchLink({
+          url: '/api/trpc',
+        }),
+      ],
+    })
+  );
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </trpc.Provider>
+  );
+}

--- a/src/lib/trpc/client.ts
+++ b/src/lib/trpc/client.ts
@@ -1,0 +1,4 @@
+import { createTRPCReact } from '@trpc/react-query';
+import { type AppRouter } from '@/server';
+
+export const trpc = createTRPCReact<AppRouter>({});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,26 @@
+import { publicProcedure, router } from './trpc';
+import { loanProducts } from '@/lib/mock-data';
+import {
+  loanApplicationSchema,
+  loanProductSchema,
+} from '@/lib/schemas';
+
+export const appRouter = router({
+  getLoanProducts: publicProcedure
+    .output(loanProductSchema.array())
+    .query(() => {
+      return loanProducts;
+    }),
+  submitApplication: publicProcedure
+    .input(loanApplicationSchema)
+    .output(loanApplicationSchema)
+    .mutation(({ input }) => {
+      const newApplication = {
+        ...input,
+      };
+      console.log('New application received:', newApplication);
+      return newApplication;
+    }),
+});
+
+export type AppRouter = typeof appRouter;

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -1,0 +1,7 @@
+import { initTRPC } from '@trpc/server';
+
+
+const t = initTRPC.create();
+
+export const router = t.router;
+export const publicProcedure = t.procedure;


### PR DESCRIPTION
this moves our api from a classic rest setup to trpc, which gives us type safety from the database all the way to the browser.

the main goal was to make things safer and easier to work with. now, if the api changes, we'll know about it right away instead of finding out when something breaks in production.

- swapped out the manual fetch calls for a single trpc router.
- using zod schemas now, so we could get rid of the handwritten types file.
- updated the ui to use the cleaner trpc hooks for fetching and sending data.
- deleted all the old, unneeded api files to tidy things up.