### PR TITLE
026_responsive_gradient_images

### DIFF
--- a/src/components/GradientOverlaySection.tsx
+++ b/src/components/GradientOverlaySection.tsx
@@ -73,18 +73,18 @@ const GradientOverlaySection: React.FC<GradientOverlaySectionProps> = ({
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12 lg:gap-16 items-start">
           <div className="flex flex-col justify-center">
             <motion.div
-              className="relative flex justify-center items-start space-x-12 px-4 py-8"
+              className="relative flex flex-row items-start justify-center px-4 py-8 space-x-4 md:space-x-12"
               variants={containerVariants}
               initial="hidden"
               animate={inView ? 'visible' : 'hidden'}
             >
-              <motion.div variants={itemVariants} className="w-[420px] h-96 rounded-md shadow-lg overflow-hidden">
+              <motion.div variants={itemVariants} className="w-1/2 md:w-[420px] h-96 rounded-md shadow-lg overflow-hidden">
                 <Image src="/building-2.webp" alt="Building 2" width={420} height={384} className="object-cover w-full h-full" />
               </motion.div>
-              <motion.div variants={itemVariants} className="w-[420px] h-96 rounded-md shadow-lg relative top-16 overflow-hidden">
+              <motion.div variants={itemVariants} className="w-1/2 md:w-[420px] h-96 rounded-md shadow-lg overflow-hidden md:translate-y-16">
                 <Image src="/building-3.webp" alt="Building 3" width={420} height={384} className="object-cover w-full h-full" />
               </motion.div>
-              <motion.div variants={itemVariants} className="w-[420px] h-96 rounded-md shadow-lg relative top-32 overflow-hidden">
+              <motion.div variants={itemVariants} className="w-[420px] h-96 rounded-md shadow-lg overflow-hidden hidden md:block md:translate-y-32">
                 <Image src="/building-4.webp" alt="Building 4" width={420} height={384} className="object-cover w-full h-full" />
               </motion.div>
             </motion.div>
@@ -96,7 +96,7 @@ const GradientOverlaySection: React.FC<GradientOverlaySectionProps> = ({
 
           {/* Right Column - Text Content */}
           <motion.div
-            className="relative flex flex-col justify-center pt-16 md:pt-8 text-left"
+            className="relative flex flex-col justify-center pt-2 md:pt-8 text-left"
             variants={textContainerVariants}
             initial="hidden"
             animate={inView ? 'visible' : 'hidden'}

--- a/src/components/NextGenFinancing.tsx
+++ b/src/components/NextGenFinancing.tsx
@@ -55,7 +55,7 @@ const NextGenFinancing = () => {
   return (
     <section style={{ backgroundColor: '#fdfcf7' }} className="w-full font-gestiva overflow-hidden md:p-24 ">
       <div className="w-full">
-        <h2 className="text-[3rem] md:text-[4rem] font-bold text-center my-12 text-gray-800 next-gen-title">Next Gen Financing</h2>
+        <h2 className="text-[3rem] md:text-[4rem] font-bold text-center my-12 text-gray-800 next-gen-title" style={{ fontWeight: 'bold'}}>Next Gen Financing</h2>
         <div className="w-full">
           {financingData.map((item, index) => (
             <div key={item.id}>

--- a/src/components/ValueProposition.tsx
+++ b/src/components/ValueProposition.tsx
@@ -15,7 +15,7 @@ const ValueProposition = () => {
         <div className="flex w-full items-center justify-center text-center md:w-1/2 md:pr-8 md:text-left">
           <h2
             className="text-4xl leading-tight md:text-6xl"
-            style={{ fontFamily: "'Gestiva', serif" }}
+            style={{ fontFamily: "'Gestiva', serif", fontWeight: 'bold' }}
           >
             Unlocking Smart Capital For Data-Driven Investors
           </h2>


### PR DESCRIPTION
feat: adjust gradient section images for mobile

- hide third image on smaller screens
- widen remaining two images for better mobile view
- ensure desktop layout remains unchanged